### PR TITLE
fix: fonts-noto-cjkを追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     fonts-noto-cjk \
     # フォントキャッシュ管理
     fontconfig && \
-    fc-cache -fv && \
+    fc-cache -f && \
     rm -rf /var/lib/apt/lists/* && \
     echo "✅ システムパッケージが正常にインストールされました"
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,12 @@ RUN apt-get update && \
     python3 \
     python3-pip \
     # PDF関連ツール
-    poppler-utils && \
+    poppler-utils \
+    # 日本語フォント
+    fonts-noto-cjk \
+    # フォントキャッシュ管理
+    fontconfig && \
+    fc-cache -fv && \
     rm -rf /var/lib/apt/lists/* && \
     echo "✅ システムパッケージが正常にインストールされました"
 


### PR DESCRIPTION
## 変更内容
<!-- このプルリクエストで何を変更したか簡潔に説明してください -->
- fonts-noto-cjk を追加しJupyterで使えるようにしました
 
## 変更理由
<!-- なぜこの変更が必要だったか説明してください -->
- Jupyterで日本語フォントが使えないのが困っていた

## テスト
<!-- どのようなテストを行ったか説明してください -->
- [ ] ローカル環境でテスト済み
- [x] devcontainer環境でテスト済み
- [x] LaTeXビルドが正常に動作することを確認
- [x] 各言語のサンプルコードが動作することを確認

## チェックリスト
- [x] コードが既存のスタイルに従っている
- [x] 自己レビューを行った
- [x] コメントを追加した（特に理解しにくい部分）
- [ ] ドキュメントを更新した
- [ ] 変更により新しい警告が発生しない
- [ ] テストを追加した（必要に応じて）

## 追加情報
<!-- その他の情報があれば記載してください --> 